### PR TITLE
Add Invert-X and use inversion controls for mouse

### DIFF
--- a/scenes/common/player_characters/player_movement_controller.gd
+++ b/scenes/common/player_characters/player_movement_controller.gd
@@ -38,6 +38,7 @@ var mouse_position := Vector2(950.0, 480.0)
 var mouse_travel := Vector2.ZERO
 # Controller
 var invert_y := false
+var invert_x := false
 var x_sensitivity := BASE_X_SENS
 var y_sensitivity := BASE_Y_SENS
 # Movement
@@ -69,6 +70,7 @@ func _ready() -> void:
 	x_sensitivity *= SavedVariables.save_data["settings"]["x_sens"]
 	y_sensitivity *= SavedVariables.save_data["settings"]["y_sens"]
 	invert_y = SavedVariables.save_data["settings"]["invert_y"]
+	invert_x = SavedVariables.save_data["settings"]["invert_x"]
 	spectate_mode = Global.spectate_mode
 	GameEvents.spectate_mode_changed.connect(on_spectate_mode_changed)
 	GameEvents.variable_saved.connect(on_variable_saved)
@@ -144,7 +146,10 @@ func _physics_process(delta : float) -> void:
 	# Handle Controller right stick (camera)
 	var cam_input := Input.get_vector("look_left", "look_right", "look_up", "look_down")
 	if cam_input.length_squared() > 0.0:
-		twist_input = - cam_input.x * x_sensitivity
+		if invert_x:
+			twist_input = cam_input.x * x_sensitivity
+		else:
+			twist_input = - cam_input.x * x_sensitivity
 		if invert_y:
 			pitch_input = cam_input.y * y_sensitivity
 		else:
@@ -206,8 +211,14 @@ func _unhandled_input(event : InputEvent) -> void:
 	# Mouse motion.
 	if event is InputEventMouseMotion:
 		if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-			twist_input = - event.relative.x * mouse_sensitivity
-			pitch_input = - event.relative.y * mouse_sensitivity
+			if invert_x:
+				twist_input = event.relative.x * mouse_sensitivity
+			else:
+				twist_input = - event.relative.x * mouse_sensitivity
+			if invert_y:
+				pitch_input = event.relative.y * mouse_sensitivity
+			else:
+				pitch_input = - event.relative.y * mouse_sensitivity
 			# Get left click movement to exclude click/drags
 			mouse_travel += event.relative
 	# Mouse button pressed.
@@ -287,11 +298,12 @@ func on_spectate_mode_changed() -> void:
 
 # Used to update sensitivity when changed in controls menu.
 func on_variable_saved(_section: String, key: String, _value: Variant) -> void:
-	if key.contains("sens") or key == "invert_y":
+	if key.contains("sens") or key.contains("invert_"):
 		mouse_sensitivity = BASE_MOUSE_SENS * SavedVariables.save_data["settings"]["mouse_sens"]
 		x_sensitivity = BASE_Y_SENS * SavedVariables.save_data["settings"]["x_sens"]
 		y_sensitivity = BASE_Y_SENS * SavedVariables.save_data["settings"]["y_sens"]
 		invert_y = SavedVariables.save_data["settings"]["invert_y"]
+		invert_x = SavedVariables.save_data["settings"]["invert_x"]
 
 
 # Resets camera position to fix it getting desync'd when leaving spectate mode.

--- a/scenes/menus/control_menu.gd
+++ b/scenes/menus/control_menu.gd
@@ -16,6 +16,7 @@ enum {SPRINT, ARMS, DASH, RESET}
 @onready var x_sens_h_slider: HSlider = %XSensHSlider
 @onready var y_sens_h_slider: HSlider = %YSensHSlider
 @onready var invert_y_check_button: CheckButton = %InvertYCheckButton
+@onready var invert_x_check_button: CheckButton = %InvertXCheckButton
 
 var awaited_key: Variant
 var saved_var_keys := ["ab1_sprint", "ab2_arms", "ab3_dash", "reset"]
@@ -33,6 +34,7 @@ func _ready() -> void:
 	x_sens_h_slider.set_value_no_signal(SavedVariables.save_data["settings"]["x_sens"])
 	y_sens_h_slider.set_value_no_signal(SavedVariables.save_data["settings"]["y_sens"])
 	invert_y_check_button.set_pressed_no_signal(SavedVariables.save_data["settings"]["invert_y"])
+	invert_x_check_button.set_pressed_no_signal(SavedVariables.save_data["settings"]["invert_x"])
 
 
 func _unhandled_input(event : InputEvent) -> void:
@@ -100,6 +102,10 @@ func _on_y_sens_h_slider_drag_ended(value_changed: bool) -> void:
 
 func _on_invert_y_check_button_toggled(toggled_on: bool) -> void:
 	GameEvents.emit_variable_saved("settings", "invert_y", toggled_on)
+	
+
+func _on_invert_x_check_button_toggled(toggled_on: bool) -> void:
+	GameEvents.emit_variable_saved("settings", "invert_x", toggled_on)
 
 
 func _on_back_button_pressed() -> void:

--- a/scenes/menus/control_menu.tscn
+++ b/scenes/menus/control_menu.tscn
@@ -231,6 +231,21 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 6
 
+[node name="InvertXContainer" type="HBoxContainer" parent="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox"]
+layout_mode = 2
+theme_override_constants/separation = 57
+
+[node name="InvertXLabel" type="Label" parent="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer"]
+custom_minimum_size = Vector2(250, 0)
+layout_mode = 2
+text = "Invert X"
+label_settings = SubResource("LabelSettings_iqfvl")
+
+[node name="InvertXCheckButton" type="CheckButton" parent="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 6
+
 [node name="BottomHBoxContainer" type="HBoxContainer" parent="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox"]
 layout_mode = 2
 size_flags_vertical = 10
@@ -253,4 +268,5 @@ text = "Close"
 [connection signal="drag_ended" from="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/XSensContainer/XSensHSlider" to="." method="_on_x_sens_h_slider_drag_ended"]
 [connection signal="drag_ended" from="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/YSensContainer2/YSensHSlider" to="." method="_on_y_sens_h_slider_drag_ended"]
 [connection signal="toggled" from="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertYContainer/InvertYCheckButton" to="." method="_on_invert_y_check_button_toggled"]
+[connection signal="toggled" from="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer/InvertXCheckButton" to="." method="_on_invert_x_check_button_toggled"]
 [connection signal="pressed" from="KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/BottomHBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/menus/keybinds_menu_container.gd
+++ b/scenes/menus/keybinds_menu_container.gd
@@ -16,6 +16,7 @@ enum {SPRINT, ARMS, DASH}
 @onready var x_sens_h_slider: HSlider = %XSensHSlider
 @onready var y_sens_h_slider: HSlider = %YSensHSlider
 @onready var invert_y_check_button: CheckButton = %InvertYCheckButton
+@onready var invert_x_check_button: CheckButton = %InvertXCheckButton
 
 var awaited_key: Variant
 var saved_var_keys := ["ab1_sprint", "ab2_arms", "ab3_dash"]
@@ -32,6 +33,7 @@ func _ready() -> void:
 	x_sens_h_slider.set_value_no_signal(SavedVariables.save_data["settings"]["x_sens"])
 	y_sens_h_slider.set_value_no_signal(SavedVariables.save_data["settings"]["y_sens"])
 	invert_y_check_button.set_pressed_no_signal(SavedVariables.save_data["settings"]["invert_y"])
+	invert_x_check_button.set_pressed_no_signal(SavedVariables.save_data["settings"]["invert_x"])
 
 
 func _unhandled_input(event : InputEvent) -> void:
@@ -85,6 +87,10 @@ func _on_y_sens_h_slider_drag_ended(value_changed: bool) -> void:
 
 func _on_invert_y_check_button_toggled(toggled_on: bool) -> void:
 	GameEvents.emit_variable_saved("settings", "invert_y", toggled_on)
+
+
+func _on_invert_x_check_button_toggled(toggled_on: bool) -> void:
+	GameEvents.emit_variable_saved("settings", "invert_x", toggled_on)
 
 
 func _on_back_button_pressed() -> void:

--- a/scenes/menus/main_menu.tscn
+++ b/scenes/menus/main_menu.tscn
@@ -721,6 +721,21 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 6
 
+[node name="InvertXContainer" type="HBoxContainer" parent="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox"]
+layout_mode = 2
+theme_override_constants/separation = 57
+
+[node name="InvertXLabel" type="Label" parent="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer"]
+custom_minimum_size = Vector2(250, 0)
+layout_mode = 2
+text = "Invert X"
+label_settings = SubResource("LabelSettings_8x8sj")
+
+[node name="InvertXCheckButton" type="CheckButton" parent="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 6
+
 [node name="BottomHBoxContainer" type="HBoxContainer" parent="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox"]
 layout_mode = 2
 size_flags_vertical = 10
@@ -1111,6 +1126,7 @@ libraries = {
 [connection signal="drag_ended" from="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/XSensContainer/XSensHSlider" to="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer" method="_on_x_sens_h_slider_drag_ended"]
 [connection signal="drag_ended" from="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/YSensContainer2/YSensHSlider" to="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer" method="_on_y_sens_h_slider_drag_ended"]
 [connection signal="toggled" from="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertYContainer/InvertYCheckButton" to="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer" method="_on_invert_y_check_button_toggled"]
+[connection signal="toggled" from="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/InvertXContainer/InvertXCheckButton" to="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer" method="_on_invert_x_check_button_toggled"]
 [connection signal="pressed" from="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer/MarginContainer/LeftButtonsVBox/BottomHBoxContainer/BackButton" to="MenuContainer/MarginContainer/VBoxContainer/KeybindsMenuContainer" method="_on_back_button_pressed"]
 [connection signal="pressed" from="MenuContainer/MarginContainer/VBoxContainer/LineupMenuContainer/MarginContainer/LeftButtonsVBox/DefaultButton" to="MenuContainer/MarginContainer/VBoxContainer/LineupMenuContainer" method="_on_default_button_pressed"]
 [connection signal="pressed" from="MenuContainer/MarginContainer/VBoxContainer/LineupMenuContainer/MarginContainer/LeftButtonsVBox/T1Container/UpButton" to="MenuContainer/MarginContainer/VBoxContainer/LineupMenuContainer/MarginContainer/LeftButtonsVBox/T1Container" method="_on_up_button_pressed"]

--- a/scripts/autoload/saved_variables.gd
+++ b/scripts/autoload/saved_variables.gd
@@ -20,6 +20,7 @@ var save_data: Dictionary = {
 		"x_sens": 1.0,
 		"y_sens": 1.0,
 		"invert_y": false,
+		"invert_x": false,
 		"selected_seq": 0,
 		"p2_lr_strat": 0,  # [NAUR, LPDU]
 		"p3_sa_strat": 0,  # [NAUR, LPDU]


### PR DESCRIPTION
This expands upon the Invert-Y settings for controllers, adding in an Invert-X, and using the option for both controller and mouse camera movement. A member of my static uses this camera movement in-game, so I figured I could add it. He's been testing a local build and it has seemed to work well so far. Happy to make adjustments if requested